### PR TITLE
fix: make the default network testnet

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 const debug = require('debug')('main')
 const app = require('./app')
 
-const network = process.env.NETWORK
+const network = process.env.NETWORK || 'testnet'
 const dev = process.env.DEV
 
 app({ network, dev })


### PR DESCRIPTION
To avoid confusion when using the AppImage we have set the default network to be testnet so we don't have to use an environnement variable.